### PR TITLE
Livereload

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # nanotron
 
-Small opinionated dev program for developing Electron apps using the nano* stack (the modules backing Choo.js)
+Small opinionated dev program for developing Electron apps
 
 ```
 npm install -g nanotron
@@ -9,18 +9,13 @@ npm install -g nanotron
 ## Usage
 
 ```
-# Browserifies ./index.js and wraps it in a Electron shell while applying the below transforms.
-# To reload, press CMD-R.
+# Browserifies ./index.js and wraps it in a Electron shell
 nanotron
 ```
-
-Comes with transforms enabled for envify, sheetify, and nanohtml.
 
 * Uses the locally installed `electron`, otherwise the one bundled with this module.
 * If `electron.js` exists, this file will be required as part of the electron process
 * If `index.html` exists this file will be used as the html wrapper.
-* The compiled js is available as `FILE.bundle.js` in the index.html page.
-* Loads your sheetify settings from your package.json.
 
 ## License
 

--- a/bin.js
+++ b/bin.js
@@ -38,7 +38,7 @@ const opts = {
   basedir: fileDir,
   cache: {},
   packageCache: {},
-  plugin: [ watchify ],
+  plugin: [watchify],
   debug: true
 }
 
@@ -50,7 +50,7 @@ for (const e of [].concat(argv.exclude || [])) b.exclude(e)
 b.transform(envify({ NODE_ENV: process.env.NODE_ENV }))
 
 bundle(() => {
-  const proc = spawn(electron, [ path.join(__dirname, 'electron.js') ], { stdio: 'inherit' })
+  const proc = spawn(electron, [path.join(__dirname, 'electron.js')], { stdio: 'inherit' })
   proc.on('close', (code) => process.exit(code))
 
   b.on('error', err => {
@@ -75,7 +75,7 @@ function bundle (cb) {
 }
 
 function localRequire (name) {
-  const localPaths = [ path.join(process.cwd(), 'node_modules') ]
+  const localPaths = [path.join(process.cwd(), 'node_modules')]
   while (true) {
     const top = localPaths[localPaths.length - 1]
     const next = path.resolve(top, '../..', 'node_modules')

--- a/bin.js
+++ b/bin.js
@@ -44,16 +44,10 @@ const opts = {
 
 const b = browserify(file, opts)
 
-const sheetify = localRequire('sheetify/transform')
-const nanohtml = localRequire('nanohtml')
-
 b.exclude('electron')
 for (const e of [].concat(argv.exclude || [])) b.exclude(e)
 
 b.transform(envify({ NODE_ENV: process.env.NODE_ENV }))
-if (sheetify) b.transform(sheetify, pkg.sheetify || {})
-if (nanohtml) b.transform(nanohtml)
-
 
 bundle(() => {
   const proc = spawn(electron, [ path.join(__dirname, 'electron.js') ], { stdio: 'inherit' })

--- a/bin.js
+++ b/bin.js
@@ -8,6 +8,7 @@ const envify = require('envify/custom')
 const watchify = require('watchify')
 const minimist = require('minimist')
 const path = require('path')
+const os = require('os')
 const fs = require('fs')
 const pump = require('pump')
 
@@ -35,7 +36,7 @@ const file = path.resolve(argv._[0] || 'index.js')
 const fileDir = path.dirname(file)
 
 if (!process.argv[2] && !fs.existsSync(file)) fs.writeFileSync(file, '')
-const fileBundle = path.join(fileDir, path.basename(file, '.js') + '.bundle.js')
+const fileBundle = path.join(os.tmpdir(), path.basename(file, '.js') + '.bundle.js')
 process.env.BUNDLE_PATH = fileBundle
 
 const opts = {
@@ -69,9 +70,8 @@ bundle(() => {
 })
 
 function bundle (cb) {
-  pump(b.bundle(), fs.createWriteStream(fileBundle + '.tmp'), function (err) {
     if (err) console.error(err.message)
-    else fs.renameSync(fileBundle + '.tmp', fileBundle)
+  pump(b.bundle(), fs.createWriteStream(fileBundle), function (err) {
     if (cb) cb()
   })
 }

--- a/bin.js
+++ b/bin.js
@@ -12,7 +12,6 @@ const os = require('os')
 const fs = require('fs')
 const pump = require('pump')
 
-let pkg
 const argv = minimist(process.argv.slice(2), {
   alias: {
     e: 'exclude',
@@ -23,12 +22,6 @@ const argv = minimist(process.argv.slice(2), {
 if (argv.help) {
   console.error('nanotron [options]\n  -e, --exclude [module-name]')
   process.exit(0)
-}
-
-try {
-  pkg = require(path.resolve('package.json'))
-} catch (_) {
-  pkg = {}
 }
 
 const electron = localRequire('electron') || require('electron')

--- a/electron.js
+++ b/electron.js
@@ -27,7 +27,7 @@ app.on('ready', function () {
   win.webContents.on('context-menu', onContextMenu)
 
   process.on('SIGHUP', () => {
-    win.loadURL('file://' + require.resolve('./index.html'))
+    win.loadURL(win.webContents.getURL())
   })
 })
 

--- a/electron.js
+++ b/electron.js
@@ -25,6 +25,10 @@ app.on('ready', function () {
   win.loadURL('file://' + require.resolve('./index.html'))
   win.webContents.on('did-finish-load', () => win.webContents.openDevTools({ mode: 'detach' }))
   win.webContents.on('context-menu', onContextMenu)
+
+  process.on('SIGHUP', () => {
+    win.loadURL('file://' + require.resolve('./index.html'))
+  })
 })
 
 if (fs.existsSync('electron.js')) {

--- a/package.json
+++ b/package.json
@@ -7,10 +7,10 @@
     "nanotron": "./bin.js"
   },
   "dependencies": {
-    "browserify": "^16.2.3",
+    "browserify": "^16.5.2",
     "electron": "^9.1.0",
     "envify": "^4.1.0",
-    "minimist": "^1.2.0",
+    "minimist": "^1.2.5",
     "pump": "^3.0.0",
     "watchify": "^3.11.1"
   },

--- a/package.json
+++ b/package.json
@@ -17,12 +17,12 @@
   "devDependencies": {},
   "repository": {
     "type": "git",
-    "url": "https://github.com/mafintosh/nanotron.git"
+    "url": "https://github.com/hyperdivision/nanotron.git"
   },
   "author": "Mathias Buus (@mafintosh)",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/mafintosh/nanotron/issues"
+    "url": "https://github.com/hyperdivision/nanotron/issues"
   },
-  "homepage": "https://github.com/mafintosh/nanotron"
+  "homepage": "https://github.com/hyperdivision/nanotron"
 }


### PR DESCRIPTION
This make live reload work by sending a `SIGHUP`. Errors are written to the JS file and the console for easier debugging, with paths rewritten to the cwd.

It also breaks compat by removing sheetify and nanohtml. Those now have to be in a local `browserify.transform` field of the module